### PR TITLE
Add support for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
   ],
   "require": {
     "php": ">=7.1",
-    "illuminate/support": "5.*|6.*|7.*|8.*",
-    "illuminate/database": "5.*|6.*|7.*|8.*",
-    "illuminate/pagination": "5.*|6.*|7.*|8.*",
-    "illuminate/encryption": "5.*|6.*|7.*|8.*",
-    "guzzlehttp/guzzle": "6.2.*|6.3.*|7.*|8.*"
+    "illuminate/support": "5.*|6.*|7.*|8.*|9.x",
+    "illuminate/database": "5.*|6.*|7.*|8.*|9.x",
+    "illuminate/pagination": "5.*|6.*|7.*|8.*|9.x",
+    "illuminate/encryption": "5.*|6.*|7.*|8.*|9.x",
+    "guzzlehttp/guzzle": "6.2.*|6.3.*|7.*|8.*|9.x"
   },
   "require-dev": {
     "fzaninotto/faker": "~1.4",


### PR DESCRIPTION
This bumps the required PHP dependency versions to support Laravel 9.