### PR TITLE
Fix property name in processColumnListing

### DIFF
--- a/src/Poyii/Informix/Query/Processors/IfxProcessor.php
+++ b/src/Poyii/Informix/Query/Processors/IfxProcessor.php
@@ -19,7 +19,7 @@ class IfxProcessor extends Processor
         $mapping = function ($r) {
             $r = (object) $r;
 
-            return $r->column_name;
+            return $r->colname;
         };
 
         return array_map($mapping, $results);


### PR DESCRIPTION
Fixes #5, at least for the instance of Informix I'm working with. I believe it makes the name of the column storing a table's given column name align with the name [here](https://github.com/isoc-il/laravel-ifx/blob/4384e5c0ae1a642ded6272e87d8495eadd4fa5ad/src/Poyii/Informix/Schema/Grammars/IfxGrammar.php#L39).